### PR TITLE
Disable php error display on php/api.php

### DIFF
--- a/php/api.php
+++ b/php/api.php
@@ -10,6 +10,7 @@
 @ini_set('upload_max_size', '200M');
 @ini_set('upload_max_filesize', '20M');
 @ini_set('max_file_uploads', '100');
+@ini_set('display_errors', '0');
 
 if (!empty($_POST['function'])||!empty($_GET['function'])) {
 

--- a/php/modules/Users.php
+++ b/php/modules/Users.php
@@ -33,7 +33,7 @@ class Users extends Module {
       }
       $result = $this->database->query($query);
 
-      $data = [];
+      $data = array();
       while($row = $result->fetch_assoc()){
         $data[] = $row;
       }
@@ -162,7 +162,7 @@ class Users extends Module {
           return false;
       }
 
-      $data = [];
+      $data = array();
       while($row = $result->fetch_assoc()){
         $data[] = $row;
       }


### PR DESCRIPTION
This was causing some very strange side-effects, in particular, a
nearly inexplicable situation where the display would turn into a
fully gray screen with a black border separating the header from
body, but no contents or buttons showing. This would happen every
time any warning/error/notice/etc. was injected into the output of
the script.
