### PR TITLE
Recover missing session variables from cookie

### DIFF
--- a/php/modules/Session.php
+++ b/php/modules/Session.php
@@ -65,10 +65,14 @@ class Session extends Module {
 		}
 
 		# Check login with crypted hash
-		if(isset( $_COOKIE['SESSION']) && $this->sessionExists($_COOKIE['SESSION']) ){
+		if(isset($_COOKIE['LYCHEEUSER']) && isset( $_COOKIE['SESSION']) && $this->sessionExists($_COOKIE['SESSION']) ){
 			$_SESSION['login']		= true;
 			$_SESSION['identifier']	= $this->settings['identifier'];
 			$public = false;
+			$userdets = explode(":", $_COOKIE['LYCHEEUSER']);
+			$_SESSION['userid'] = $userdets[0];
+			$_SESSION['username'] = $userdets[1];
+			$_SESSION['role'] = $userdets[2];
 		}
  
 		if ($public===false) {
@@ -127,6 +131,7 @@ class Session extends Module {
 				$result = $this->database->query($query);
 
 				setcookie("SESSION", $hash, $expire, "/","", false, true);
+				setcookie("LYCHEEUSER", $_SESSION['userid'].":".$_SESSION['username'].":".$_SESSION['role'], $expire, "/","", false, true);
 
 				return array('role' => $_SESSION['role']);
 		}


### PR DESCRIPTION
When the server clears out the session, we lose the data stored in it.
This takes that data and stores it in a cookie, and when the data is
lost, recovers it from the cookie.

This fixes https://github.com/Aidenir/Lychee/issues/5
